### PR TITLE
Allow to pass struct module name for struct validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Future version
+
+### Changes
+
+- allow to pass struct module name in `struct` validation
+
 ## [1.2.0] - 2018.11.17
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ Checks whether the given parameter is expected structure.
 
 ```elixir
 parameter :some_param, struct: %SomeStruct{}
+# or
+parameter :some_param, struct: SomeStruct
 ```
 
 #### `list_item`

--- a/lib/exop/validation_checks.ex
+++ b/lib/exop/validation_checks.ex
@@ -374,18 +374,9 @@ defmodule Exop.ValidationChecks do
   """
   @spec check_struct(Keyword.t() | map(), atom() | String.t(), struct()) :: true | check_error
   def check_struct(check_items, item_name, check) do
-    check_item = get_check_item(check_items, item_name)
-
-    try do
-      check = struct!(check, Map.from_struct(check_item))
-      ^check_item = check
-    rescue
-      _ ->
-        %{item_name => "is not expected struct"}
-    else
-      _ ->
-        true
-    end
+    check_items
+    |> get_check_item(item_name)
+    |> validate_struct(check, item_name)
   end
 
   @doc """
@@ -458,4 +449,10 @@ defmodule Exop.ValidationChecks do
   def check_exactly(check_items, item_name, check_value) do
     check_equals(check_items, item_name, check_value)
   end
+
+  defp validate_struct(%struct{}, %struct{}, _item_name), do: true
+
+  defp validate_struct(%struct{}, struct, _item_name) when is_atom(struct), do: true
+
+  defp validate_struct(_item, _check, item_name), do: %{item_name => "is not expected struct"}
 end

--- a/test/validation_checks_test.exs
+++ b/test/validation_checks_test.exs
@@ -193,9 +193,10 @@ defmodule ValidationChecksTest do
   end
 
   test "check_struct/3: successes" do
-    assert check_struct(%{a: %TestStruct{qwerty: "123"}}, :a, %TestStruct{}) == true
     struct = %TestStruct{qwerty: "123"}
+
     assert check_struct(%{a: struct}, :a, %TestStruct{}) == true
+    assert check_struct(%{a: struct}, :a, TestStruct) == true
   end
 
   test "check_struct/3: fails" do
@@ -203,6 +204,8 @@ defmodule ValidationChecksTest do
     assert check_struct(%{a: %TestStruct2{qwerty: "123"}}, :a, %TestStruct{}) == %{a: "is not expected struct"}
     assert check_struct(%{a: %TestStruct2{}}, :a, %TestStruct{qwerty: "123"}) == %{a: "is not expected struct"}
     assert check_struct(%{a: %TestStruct2{qwerty: "123"}}, :a, %TestStruct{qwerty: "123"}) == %{a: "is not expected struct"}
+    assert check_struct(%{a: %TestStruct2{}}, :a, TestStruct) == %{a: "is not expected struct"}
+    assert check_struct(%{a: %TestStruct2{qwerty: "123"}}, :a, TestStruct) == %{a: "is not expected struct"}
   end
 
   test "check_equals/3: success" do


### PR DESCRIPTION
Sometimes it is not possible to use concrete value in `struct` validation. For example if struct contains `@enforce_keys`:

```elixir
parameter :birthday, struct: %Date{}

# ** (ArgumentError) the following keys must also be given when building struct Date: [:year, :month, :day]
```

So now it is possible to specify struct module name in `struct` validation:

```elixir
parameter :birthday, struct: Date
```