### PR TITLE
Basic got extension

### DIFF
--- a/lib/exop/validation_checks.ex
+++ b/lib/exop/validation_checks.ex
@@ -116,7 +116,8 @@ defmodule Exop.ValidationChecks do
     if check_item_present?(check_items, item_name) do
       check_item = get_check_item(check_items, item_name)
 
-      TypeValidation.check_value(check_item, check) || %{item_name => "has wrong type"}
+      TypeValidation.check_value(check_item, check) ||
+        %{item_name => "has wrong type. expected type: #{check}, got: #{inspect(check_item)}"}
     else
       true
     end
@@ -147,7 +148,7 @@ defmodule Exop.ValidationChecks do
           if Enum.all?(result, &(&1 == true)), do: true, else: result
 
         true ->
-          %{item_name => "not a number"}
+          %{item_name => "not a number. got: #{inspect(check_item)}"}
       end
     else
       true
@@ -156,7 +157,7 @@ defmodule Exop.ValidationChecks do
 
   @spec check_number(number, atom() | String.t(), {atom, number}) :: boolean
   defp check_number(number, item_name, {:equal_to, check_value}) do
-    if number == check_value, do: true, else: %{item_name => "must be equal to #{check_value}"}
+    if number == check_value, do: true, else: %{item_name => "must be equal to #{check_value}. got: #{inspect number}"}
   end
 
   defp check_number(number, item_name, {:eq, check_value}) do
@@ -172,7 +173,7 @@ defmodule Exop.ValidationChecks do
   end
 
   defp check_number(number, item_name, {:greater_than, check_value}) do
-    if number > check_value, do: true, else: %{item_name => "must be greater than #{check_value}"}
+    if number > check_value, do: true, else: %{item_name => "must be greater than #{check_value}. got: #{inspect number}"}
   end
 
   defp check_number(number, item_name, {:gt, check_value}) do
@@ -182,7 +183,7 @@ defmodule Exop.ValidationChecks do
   defp check_number(number, item_name, {:greater_than_or_equal_to, check_value}) do
     if number >= check_value,
       do: true,
-      else: %{item_name => "must be greater than or equal to #{check_value}"}
+      else: %{item_name => "must be greater than or equal to #{check_value}. got: #{inspect number}"}
   end
 
   defp check_number(number, item_name, {:min, check_value}) do
@@ -204,7 +205,7 @@ defmodule Exop.ValidationChecks do
   defp check_number(number, item_name, {:less_than_or_equal_to, check_value}) do
     if number <= check_value,
       do: true,
-      else: %{item_name => "must be less than or equal to #{check_value}"}
+      else: %{item_name => "must be less than or equal to #{check_value}. got: #{inspect number}"}
   end
 
   defp check_number(number, item_name, {:lte, check_value}) do
@@ -234,7 +235,7 @@ defmodule Exop.ValidationChecks do
     if Enum.member?(check_list, check_item) do
       true
     else
-      %{item_name => "must be one of #{inspect(check_list)}"}
+      %{item_name => "must be one of #{inspect(check_list)}. got: #{inspect check_item}"}
     end
   end
 
@@ -253,7 +254,7 @@ defmodule Exop.ValidationChecks do
     check_item = get_check_item(check_items, item_name)
 
     if Enum.member?(check_list, check_item) do
-      %{item_name => "must not be included in #{inspect(check_list)}"}
+      %{item_name => "must not be included in #{inspect(check_list)}. got: #{inspect check_item}"}
     else
       true
     end
@@ -277,7 +278,7 @@ defmodule Exop.ValidationChecks do
       if Regex.match?(check, check_item) do
         true
       else
-        %{item_name => "has invalid format"}
+        %{item_name => "has invalid format. got: #{inspect check_item}"}
       end
     else
       true
@@ -343,12 +344,12 @@ defmodule Exop.ValidationChecks do
 
   defp check_length(:gte, item_name, actual_length, check_value) do
     actual_length >= check_value ||
-      %{item_name => "length must be greater than or equal to #{check_value}"}
+      %{item_name => "length must be greater than or equal to #{check_value}. got length: #{inspect actual_length}"}
   end
 
   defp check_length(:gt, item_name, actual_length, check_value) do
     actual_length > check_value ||
-      %{item_name => "length must be greater than #{check_value}"}
+      %{item_name => "length must be greater than #{check_value}. got length: #{inspect actual_length}"}
   end
 
   defp check_length(:max, item_name, actual_length, check_value) do
@@ -357,21 +358,21 @@ defmodule Exop.ValidationChecks do
 
   defp check_length(:lte, item_name, actual_length, check_value) do
     actual_length <= check_value ||
-      %{item_name => "length must be less than or equal to #{check_value}"}
+      %{item_name => "length must be less than or equal to #{check_value}. got length: #{inspect actual_length}"}
   end
 
   defp check_length(:lt, item_name, actual_length, check_value) do
     actual_length < check_value ||
-      %{item_name => "length must be less than #{check_value}"}
+      %{item_name => "length must be less than #{check_value}. got length: #{inspect actual_length}"}
   end
 
   defp check_length(:is, item_name, actual_length, check_value) do
-    actual_length == check_value || %{item_name => "length must be equal to #{check_value}"}
+    actual_length == check_value || %{item_name => "length must be equal to #{check_value}. got length: #{inspect actual_length}"}
   end
 
   defp check_length(:in, item_name, actual_length, check_value) do
     Enum.member?(check_value, actual_length) ||
-      %{item_name => "length must be in range #{check_value}"}
+      %{item_name => "length must be in range #{check_value}. got length: #{inspect actual_length}"}
   end
 
   defp check_length(check, item_name, _actual_length, _check_value) do
@@ -456,7 +457,7 @@ defmodule Exop.ValidationChecks do
     if check_item === check_value do
       true
     else
-      %{item_name => "must be equal to #{inspect(check_value)}"}
+      %{item_name => "must be equal to #{inspect(check_value)}. got: #{inspect check_item}"}
     end
   end
 

--- a/lib/exop/validation_checks.ex
+++ b/lib/exop/validation_checks.ex
@@ -195,7 +195,7 @@ defmodule Exop.ValidationChecks do
   end
 
   defp check_number(number, item_name, {:less_than, check_value}) do
-    if number < check_value, do: true, else: %{item_name => "must be less than #{check_value}"}
+    if number < check_value, do: true, else: %{item_name => "must be less than #{check_value}. got: #{inspect number}"}
   end
 
   defp check_number(number, item_name, {:lt, check_value}) do
@@ -217,7 +217,7 @@ defmodule Exop.ValidationChecks do
   end
 
   defp check_number(_number, item_name, {check, _check_value}) do
-    %{item_name => "unknwon check '#{check}'"}
+    %{item_name => "unknown check '#{check}'"}
   end
 
   @doc """
@@ -489,5 +489,6 @@ defmodule Exop.ValidationChecks do
 
   defp validate_struct(%struct{}, struct, _item_name) when is_atom(struct), do: true
 
-  defp validate_struct(_item, _check, item_name), do: %{item_name => "is not expected struct"}
+  defp validate_struct(item, check, item_name),
+       do: %{item_name => "is not expected struct. expected: #{inspect check}, got: #{inspect item}"}
 end


### PR DESCRIPTION
Based on conversation in #41.

Proof of concept for expanding error messages with `got: xyz`. All the information needed for this feature is included locally in the functions that create the validation messages. The underlying functions that do the actual error checking can stay in the same format.

@madeinussr  If this looks like what you had in mind, I will expand this PR to fix the test cases and references throughout the documentation and mark it ready for review.