### PR TITLE
1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.3.5] - yyyy.MM.dd
+
+- basic validation message extension with "got:" (credits to https://github.com/sgilson)
+makes error-tuple messages more descriptive
+- new `:subset_of` check allows you to check whether a given list is a subset of defined check-list
+
 ## [1.3.4] - 2019.09.18
 
 - a bug in `coerce_with/2` refactored behavior was fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.3.5] - yyyy.MM.dd
+## [1.3.5] - 2019.12.24
 
 - basic validation message extension with "got:" (credits to https://github.com/sgilson)
 makes error-tuple messages more descriptive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.3.5] - 2019.12.24
+## [1.3.5] - 2019.12.27
 
 - basic validation message extension with "got:" (credits to https://github.com/sgilson)
 makes error-tuple messages more descriptive

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ _This option doesn't work for `:inner` check's inner parameters currently._
 
 Checks whether a parameter's value (list) is a subset of a defined check-list.
 To pass this check, all items within given into an operation parameter should be included into check-list,
-otherwise check is failed.
+otherwise the check is failed.
 
 ```elixir
 parameter :some_param, subset_of: [1, 2, :a, "b", C]

--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
 [![Hex.pm](https://img.shields.io/hexpm/v/exop.svg)](https://hex.pm/packages/exop) [![API Docs](https://img.shields.io/badge/api-docs-yellow.svg?style=flat)](http://hexdocs.pm/exop/) [![Build Status](https://travis-ci.org/madeinussr/exop.svg?branch=master)](https://travis-ci.org/madeinussr/exop)
 
-#### New versions
-
-_Guys, too much work these days, so new releases will be shipped with some delay. However, I work on them constantly._
-
 # Exop
 
 A library that helps you to organize your Elixir code in more domain-driven way.
 Exop provides macros which helps you to encapsulate business logic and offers you additionally:
 incoming params validation (with predefined contract), params coercion, policy check, fallback behavior and more.
 
+---
+
+## Exop family:
+
 ### ExopData
 
 Interested in property-based testing? Check out new Exop family member - [ExopData](https://github.com/madeinussr/exop_data). If you use Exop to organize your code with ExopData you can get property generators in the most easiest way.
+
+### ExopPlug
+
+The new [ExopPlug](https://github.com/madeinussr/exop_plug) library provides a convenient way to validate incoming parameters of your Phoenix application's controllers by offering you small but useful DSL.
+
+---
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Here is the [CHANGELOG](https://github.com/madeinussr/exop/blob/master/CHANGELOG
     - [func](#func)
     - [allow_nil](#allow_nil)
     - [from](#from)
+    - [any_of](#any_of)
   - [Defined params](#defined-params)
   - [Interrupt](#interrupt)
   - [Coercion](#coercion)
@@ -49,7 +50,7 @@ Here is the [CHANGELOG](https://github.com/madeinussr/exop/blob/master/CHANGELOG
 
 ```elixir
 def deps do
-  [{:exop, "~> 1.3.4"}]
+  [{:exop, "~> 1.3.5"}]
 end
 ```
 
@@ -418,6 +419,21 @@ end
 Why? Simply because sometimes you're not in control of incoming parameters but don't want to map them each time you need to use'em by yourself (good example: params in Phoenix controller's action, which come as a map with string keys).
 
 _This option doesn't work for `:inner` check's inner parameters currently._
+
+#### subset_of
+
+Checks whether a parameter's value (list) is a subset of a defined check-list.
+To pass this check, all items within given into an operation parameter list should be included into check-list,
+otherwise check is failed.
+
+```elixir
+parameter :some_param, subset_of: [1, 2, :a, "b", C]
+
+# {:ok, _} = MyOperation.run(some_param: [1, :a, C])
+# {:error, _} = MyOperation.run(some_param: [3, :a, C])
+```
+
+_An empty list doesn't pass this check._
 
 ### Interrupt
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Here is the [CHANGELOG](https://github.com/madeinussr/exop/blob/master/CHANGELOG
     - [func](#func)
     - [allow_nil](#allow_nil)
     - [from](#from)
-    - [any_of](#any_of)
+    - [subset_of](#subset_of)
   - [Defined params](#defined-params)
   - [Interrupt](#interrupt)
   - [Coercion](#coercion)
@@ -429,17 +429,17 @@ _This option doesn't work for `:inner` check's inner parameters currently._
 #### subset_of
 
 Checks whether a parameter's value (list) is a subset of a defined check-list.
-To pass this check, all items within given into an operation parameter list should be included into check-list,
+To pass this check, all items within given into an operation parameter should be included into check-list,
 otherwise check is failed.
 
 ```elixir
 parameter :some_param, subset_of: [1, 2, :a, "b", C]
 
 # {:ok, _} = MyOperation.run(some_param: [1, :a, C])
+# {:ok, _} = MyOperation.run(some_param: [:a])
+# {:error, _} = MyOperation.run(some_param: [])
 # {:error, _} = MyOperation.run(some_param: [3, :a, C])
 ```
-
-_An empty list doesn't pass this check._
 
 ### Interrupt
 

--- a/lib/exop/validation.ex
+++ b/lib/exop/validation.ex
@@ -184,7 +184,7 @@ defmodule Exop.Validation do
       []
 
       iex> Exop.Validation.check_list_item(%{a: [1, :atom]}, :a, [type: :integer])
-      [[true, true], [true, %{"a[1]" => "has wrong type"}]]
+      [[true, true], [true, %{"a[1]" => "has wrong type; expected type: integer, got: :atom"}]]
 
       iex> Exop.Validation.check_list_item(%{a: [1, 2]}, :a, [type: :integer])
       [[true, true], [true, true]]

--- a/lib/exop/validation_checks.ex
+++ b/lib/exop/validation_checks.ex
@@ -109,7 +109,7 @@ defmodule Exop.ValidationChecks do
       true
 
       iex> Exop.ValidationChecks.check_type(%{a: nil}, :a, :string)
-      %{:a => "has wrong type"}
+      %{:a => "has wrong type; expected type: string, got: nil"}
   """
   @spec check_type(Keyword.t() | map(), atom() | String.t(), atom()) :: true | check_error
   def check_type(check_items, item_name, check) do
@@ -117,7 +117,7 @@ defmodule Exop.ValidationChecks do
       check_item = get_check_item(check_items, item_name)
 
       TypeValidation.check_value(check_item, check) ||
-        %{item_name => "has wrong type. expected type: #{check}, got: #{inspect(check_item)}"}
+        %{item_name => "has wrong type; expected type: #{check}, got: #{inspect(check_item)}"}
     else
       true
     end
@@ -157,7 +157,11 @@ defmodule Exop.ValidationChecks do
 
   @spec check_number(number, atom() | String.t(), {atom, number}) :: boolean
   defp check_number(number, item_name, {:equal_to, check_value}) do
-    if number == check_value, do: true, else: %{item_name => "must be equal to #{check_value}. got: #{inspect number}"}
+    if number == check_value do
+      true
+    else
+      %{item_name => "must be equal to #{check_value}; got: #{inspect(number)}"}
+    end
   end
 
   defp check_number(number, item_name, {:eq, check_value}) do
@@ -173,7 +177,11 @@ defmodule Exop.ValidationChecks do
   end
 
   defp check_number(number, item_name, {:greater_than, check_value}) do
-    if number > check_value, do: true, else: %{item_name => "must be greater than #{check_value}. got: #{inspect number}"}
+    if number > check_value do
+      true
+    else
+      %{item_name => "must be greater than #{check_value}; got: #{inspect(number)}"}
+    end
   end
 
   defp check_number(number, item_name, {:gt, check_value}) do
@@ -181,9 +189,11 @@ defmodule Exop.ValidationChecks do
   end
 
   defp check_number(number, item_name, {:greater_than_or_equal_to, check_value}) do
-    if number >= check_value,
-      do: true,
-      else: %{item_name => "must be greater than or equal to #{check_value}. got: #{inspect number}"}
+    if number >= check_value do
+      true
+    else
+      %{item_name => "must be greater than or equal to #{check_value}; got: #{inspect(number)}"}
+    end
   end
 
   defp check_number(number, item_name, {:min, check_value}) do
@@ -195,7 +205,11 @@ defmodule Exop.ValidationChecks do
   end
 
   defp check_number(number, item_name, {:less_than, check_value}) do
-    if number < check_value, do: true, else: %{item_name => "must be less than #{check_value}. got: #{inspect number}"}
+    if number < check_value do
+      true
+    else
+      %{item_name => "must be less than #{check_value}; got: #{inspect(number)}"}
+    end
   end
 
   defp check_number(number, item_name, {:lt, check_value}) do
@@ -203,9 +217,11 @@ defmodule Exop.ValidationChecks do
   end
 
   defp check_number(number, item_name, {:less_than_or_equal_to, check_value}) do
-    if number <= check_value,
-      do: true,
-      else: %{item_name => "must be less than or equal to #{check_value}. got: #{inspect number}"}
+    if number <= check_value do
+      true
+    else
+      %{item_name => "must be less than or equal to #{check_value}; got: #{inspect(number)}"}
+    end
   end
 
   defp check_number(number, item_name, {:lte, check_value}) do
@@ -235,7 +251,7 @@ defmodule Exop.ValidationChecks do
     if Enum.member?(check_list, check_item) do
       true
     else
-      %{item_name => "must be one of #{inspect(check_list)}. got: #{inspect check_item}"}
+      %{item_name => "must be one of #{inspect(check_list)}; got: #{inspect(check_item)}"}
     end
   end
 
@@ -254,7 +270,7 @@ defmodule Exop.ValidationChecks do
     check_item = get_check_item(check_items, item_name)
 
     if Enum.member?(check_list, check_item) do
-      %{item_name => "must not be included in #{inspect(check_list)}. got: #{inspect check_item}"}
+      %{item_name => "must not be included in #{inspect(check_list)}; got: #{inspect(check_item)}"}
     else
       true
     end
@@ -278,7 +294,7 @@ defmodule Exop.ValidationChecks do
       if Regex.match?(check, check_item) do
         true
       else
-        %{item_name => "has invalid format. got: #{inspect check_item}"}
+        %{item_name => "has invalid format.; got: #{inspect(check_item)}"}
       end
     else
       true
@@ -344,12 +360,20 @@ defmodule Exop.ValidationChecks do
 
   defp check_length(:gte, item_name, actual_length, check_value) do
     actual_length >= check_value ||
-      %{item_name => "length must be greater than or equal to #{check_value}. got length: #{inspect actual_length}"}
+      %{
+        item_name =>
+          "length must be greater than or equal to #{check_value}; got length: #{
+            inspect(actual_length)
+          }"
+      }
   end
 
   defp check_length(:gt, item_name, actual_length, check_value) do
     actual_length > check_value ||
-      %{item_name => "length must be greater than #{check_value}. got length: #{inspect actual_length}"}
+      %{
+        item_name =>
+          "length must be greater than #{check_value}; got length: #{inspect(actual_length)}"
+      }
   end
 
   defp check_length(:max, item_name, actual_length, check_value) do
@@ -358,21 +382,34 @@ defmodule Exop.ValidationChecks do
 
   defp check_length(:lte, item_name, actual_length, check_value) do
     actual_length <= check_value ||
-      %{item_name => "length must be less than or equal to #{check_value}. got length: #{inspect actual_length}"}
+      %{
+        item_name =>
+          "length must be less than or equal to #{check_value}; got length: #{
+            inspect(actual_length)
+          }"
+      }
   end
 
   defp check_length(:lt, item_name, actual_length, check_value) do
     actual_length < check_value ||
-      %{item_name => "length must be less than #{check_value}. got length: #{inspect actual_length}"}
+      %{
+        item_name =>
+          "length must be less than #{check_value}; got length: #{inspect(actual_length)}"
+      }
   end
 
   defp check_length(:is, item_name, actual_length, check_value) do
-    actual_length == check_value || %{item_name => "length must be equal to #{check_value}. got length: #{inspect actual_length}"}
+    actual_length == check_value ||
+      %{
+        item_name => "length must be equal to #{check_value}; got length: #{inspect(actual_length)}"
+      }
   end
 
   defp check_length(:in, item_name, actual_length, check_value) do
     Enum.member?(check_value, actual_length) ||
-      %{item_name => "length must be in range #{check_value}. got length: #{inspect actual_length}"}
+      %{
+        item_name => "length must be in range #{check_value}; got length: #{inspect(actual_length)}"
+      }
   end
 
   defp check_length(check, item_name, _actual_length, _check_value) do
@@ -457,7 +494,7 @@ defmodule Exop.ValidationChecks do
     if check_item === check_value do
       true
     else
-      %{item_name => "must be equal to #{inspect(check_value)}. got: #{inspect check_item}"}
+      %{item_name => "must be equal to #{inspect(check_value)}; got: #{inspect(check_item)}"}
     end
   end
 
@@ -489,6 +526,28 @@ defmodule Exop.ValidationChecks do
 
   defp validate_struct(%struct{}, struct, _item_name) when is_atom(struct), do: true
 
-  defp validate_struct(item, check, item_name),
-       do: %{item_name => "is not expected struct. expected: #{inspect check}, got: #{inspect item}"}
+  defp validate_struct(%struct{}, check_struct, item_name) when is_atom(check_struct) do
+    %{
+      item_name =>
+        "is not expected struct; expected: #{inspect(check_struct)}; got: #{inspect(struct)}"
+    }
+  end
+
+  defp validate_struct(item, check_struct, item_name) when is_atom(item) do
+    %{
+      item_name =>
+        "is not expected struct; expected: #{inspect(check_struct)}; got: #{inspect(item)}"
+    }
+  end
+
+  defp validate_struct(%struct{} = _item, %check_struct{}, item_name) do
+    %{
+      item_name =>
+        "is not expected struct; expected: #{inspect(check_struct)}; got: #{inspect(struct)}"
+    }
+  end
+
+  defp validate_struct(item, %check_struct{}, item_name) do
+    %{item_name => "is not expected struct; expected: #{inspect(check_struct)}; #{inspect(item)}"}
+  end
 end

--- a/lib/exop/validation_checks.ex
+++ b/lib/exop/validation_checks.ex
@@ -36,7 +36,7 @@ defmodule Exop.ValidationChecks do
       iex> Exop.ValidationChecks.get_check_item(%{a: 1, b: 2}, :c)
       nil
   """
-  @spec get_check_item(Keyword.t() | map(), atom() | String.t()) :: any() | nil
+  @spec get_check_item(map(), atom() | String.t()) :: any() | nil
   def get_check_item(check_items, item_name) when is_map(check_items) do
     Map.get(check_items, item_name)
   end
@@ -65,7 +65,7 @@ defmodule Exop.ValidationChecks do
       iex> Exop.ValidationChecks.check_item_present?(%{a: 1, b: nil}, :b)
       true
   """
-  @spec check_item_present?(Keyword.t() | map(), atom() | String.t()) :: boolean()
+  @spec check_item_present?(map(), atom() | String.t()) :: boolean()
   def check_item_present?(check_items, item_name) when is_map(check_items) do
     Map.get(check_items, item_name, @no_check_item) != @no_check_item
   end
@@ -90,7 +90,7 @@ defmodule Exop.ValidationChecks do
       iex> Exop.ValidationChecks.check_required(%{a: 1, b: 2}, :b, true)
       true
   """
-  @spec check_required(Keyword.t() | map(), atom() | String.t(), boolean) :: true | check_error
+  @spec check_required(map(), atom() | String.t(), boolean) :: true | check_error
   def check_required(_check_items, _item, false), do: true
 
   def check_required(check_items, item_name, true) do
@@ -111,7 +111,7 @@ defmodule Exop.ValidationChecks do
       iex> Exop.ValidationChecks.check_type(%{a: nil}, :a, :string)
       %{:a => "has wrong type; expected type: string, got: nil"}
   """
-  @spec check_type(Keyword.t() | map(), atom() | String.t(), atom()) :: true | check_error
+  @spec check_type(map(), atom() | String.t(), atom()) :: true | check_error
   def check_type(check_items, item_name, check) do
     if check_item_present?(check_items, item_name) do
       check_item = get_check_item(check_items, item_name)
@@ -137,7 +137,7 @@ defmodule Exop.ValidationChecks do
       iex> Exop.ValidationChecks.check_numericality(%{a: 3}, :a, %{ less_than_or_equal_to: 3 })
       true
   """
-  @spec check_numericality(Keyword.t() | map(), atom() | String.t(), map()) :: true | check_error
+  @spec check_numericality(map(), atom() | String.t(), map()) :: true | check_error
   def check_numericality(check_items, item_name, checks) do
     if check_item_present?(check_items, item_name) do
       check_item = get_check_item(check_items, item_name)
@@ -244,7 +244,7 @@ defmodule Exop.ValidationChecks do
       iex> Exop.ValidationChecks.check_in(%{a: 1}, :a, [1, 2, 3])
       true
   """
-  @spec check_in(Keyword.t() | map(), atom() | String.t(), list()) :: true | check_error
+  @spec check_in(map(), atom() | String.t(), list()) :: true | check_error
   def check_in(check_items, item_name, check_list) when is_list(check_list) do
     check_item = get_check_item(check_items, item_name)
 
@@ -265,7 +265,7 @@ defmodule Exop.ValidationChecks do
       iex> Exop.ValidationChecks.check_not_in(%{a: 4}, :a, [1, 2, 3])
       true
   """
-  @spec check_not_in(Keyword.t() | map(), atom() | String.t(), list()) :: true | check_error
+  @spec check_not_in(map(), atom() | String.t(), list()) :: true | check_error
   def check_not_in(check_items, item_name, check_list) when is_list(check_list) do
     check_item = get_check_item(check_items, item_name)
 
@@ -286,7 +286,7 @@ defmodule Exop.ValidationChecks do
       iex> Exop.ValidationChecks.check_format(%{a: "bar"}, :a, ~r/bar/)
       true
   """
-  @spec check_format(Keyword.t() | map(), atom() | String.t(), Regex.t()) :: true | check_error
+  @spec check_format(map(), atom() | String.t(), Regex.t()) :: true | check_error
   def check_format(check_items, item_name, check) do
     check_item = get_check_item(check_items, item_name)
 
@@ -310,7 +310,7 @@ defmodule Exop.ValidationChecks do
       iex> Exop.ValidationChecks.check_regex(%{a: "bar"}, :a, ~r/bar/)
       true
   """
-  @spec check_regex(Keyword.t() | map(), atom() | String.t(), Regex.t()) :: true | check_error
+  @spec check_regex(map(), atom() | String.t(), Regex.t()) :: true | check_error
   def check_regex(check_items, item_name, check) do
     check_format(check_items, item_name, check)
   end
@@ -329,7 +329,7 @@ defmodule Exop.ValidationChecks do
       iex> Exop.ValidationChecks.check_length(%{a: ~w(1 2 3)}, :a, %{is: 3, max: 4})
       [true, true]
   """
-  @spec check_length(Keyword.t() | map(), atom() | String.t(), map()) :: true | [check_error]
+  @spec check_length(map(), atom() | String.t(), map()) :: true | [check_error]
   def check_length(check_items, item_name, checks) do
     check_item = get_check_item(check_items, item_name)
 
@@ -429,7 +429,7 @@ defmodule Exop.ValidationChecks do
       Exop.ValidationChecks.check_struct(%{a: %SomeStruct1{}}, :a, %SomeStruct2{})
       # false
   """
-  @spec check_struct(Keyword.t() | map(), atom() | String.t(), struct()) :: true | check_error
+  @spec check_struct(map(), atom() | String.t(), struct()) :: true | check_error
   def check_struct(check_items, item_name, check) do
     check_items
     |> get_check_item(item_name)
@@ -453,9 +453,9 @@ defmodule Exop.ValidationChecks do
       true
   """
   @spec check_func(
-          Keyword.t() | map(),
+          map(),
           atom() | String.t(),
-          (Keyword.t() | map(), any -> true | false)
+          (map(), any -> true | false)
         ) :: true | check_error
   def check_func(check_items, item_name, check) do
     check_item = get_check_item(check_items, item_name)
@@ -487,7 +487,7 @@ defmodule Exop.ValidationChecks do
       iex> Exop.ValidationChecks.check_equals(%{a: 1}, :a, 1)
       true
   """
-  @spec check_equals(Keyword.t() | map(), atom() | String.t(), any()) :: true | check_error
+  @spec check_equals(map(), atom() | String.t(), any()) :: true | check_error
   def check_equals(check_items, item_name, check_value) do
     check_item = get_check_item(check_items, item_name)
 
@@ -507,18 +507,46 @@ defmodule Exop.ValidationChecks do
       iex> Exop.ValidationChecks.check_exactly(%{a: 1}, :a, 1)
       true
   """
-  @spec check_exactly(Keyword.t() | map(), atom() | String.t(), any()) :: true | check_error
+  @spec check_exactly(map(), atom() | String.t(), any()) :: true | check_error
   def check_exactly(check_items, item_name, check_value) do
     check_equals(check_items, item_name, check_value)
   end
 
-  @spec check_allow_nil(Keyword.t() | map(), atom() | String.t(), boolean()) :: true | check_error
+  @spec check_allow_nil(map(), atom() | String.t(), boolean()) :: true | check_error
   def check_allow_nil(_check_items, _item_name, true), do: true
 
   def check_allow_nil(check_items, item_name, false) do
     check_item = get_check_item(check_items, item_name)
 
     !is_nil(check_item) || %{item_name => "doesn't allow nil"}
+  end
+
+  @spec check_subset_of(map(), atom() | String.t(), list()) :: true | check_error
+  def check_subset_of(check_items, item_name, check_list) when is_list(check_list) do
+    check_item = get_check_item(check_items, item_name)
+
+    cond do
+      is_list(check_item) and length(check_item) > 0 ->
+        case check_item -- check_list do
+          [] ->
+            true
+
+          _ ->
+            %{
+              item_name => "must be a subset of #{inspect(check_list)}; got: #{inspect(check_item)}"
+            }
+        end
+
+      is_list(check_item) and length(check_item) == 0 ->
+        %{
+          item_name => "must be a subset of #{inspect(check_list)}; got: #{inspect(check_item)}"
+        }
+
+      not is_list(check_item) ->
+        %{
+          item_name => "must be a list; got: #{inspect(check_item)}"
+        }
+    end
   end
 
   @spec validate_struct(any(), any(), atom() | String.t()) :: boolean()

--- a/lib/exop/validation_checks.ex
+++ b/lib/exop/validation_checks.ex
@@ -116,7 +116,8 @@ defmodule Exop.ValidationChecks do
     if check_item_present?(check_items, item_name) do
       check_item = get_check_item(check_items, item_name)
 
-      TypeValidation.check_value(check_item, check) || %{item_name => "has wrong type"}
+      TypeValidation.check_value(check_item, check) ||
+        %{item_name => "has wrong type. expected type: #{check}, got: #{inspect(check_item)}"}
     else
       true
     end
@@ -147,7 +148,7 @@ defmodule Exop.ValidationChecks do
           if Enum.all?(result, &(&1 == true)), do: true, else: result
 
         true ->
-          %{item_name => "not a number"}
+          %{item_name => "not a number. got: #{inspect(check_item)}"}
       end
     else
       true
@@ -156,7 +157,7 @@ defmodule Exop.ValidationChecks do
 
   @spec check_number(number, atom() | String.t(), {atom, number}) :: boolean
   defp check_number(number, item_name, {:equal_to, check_value}) do
-    if number == check_value, do: true, else: %{item_name => "must be equal to #{check_value}"}
+    if number == check_value, do: true, else: %{item_name => "must be equal to #{check_value}. got: #{inspect number}"}
   end
 
   defp check_number(number, item_name, {:eq, check_value}) do
@@ -172,7 +173,7 @@ defmodule Exop.ValidationChecks do
   end
 
   defp check_number(number, item_name, {:greater_than, check_value}) do
-    if number > check_value, do: true, else: %{item_name => "must be greater than #{check_value}"}
+    if number > check_value, do: true, else: %{item_name => "must be greater than #{check_value}. got: #{inspect number}"}
   end
 
   defp check_number(number, item_name, {:gt, check_value}) do
@@ -182,7 +183,7 @@ defmodule Exop.ValidationChecks do
   defp check_number(number, item_name, {:greater_than_or_equal_to, check_value}) do
     if number >= check_value,
       do: true,
-      else: %{item_name => "must be greater than or equal to #{check_value}"}
+      else: %{item_name => "must be greater than or equal to #{check_value}. got: #{inspect number}"}
   end
 
   defp check_number(number, item_name, {:min, check_value}) do
@@ -194,7 +195,7 @@ defmodule Exop.ValidationChecks do
   end
 
   defp check_number(number, item_name, {:less_than, check_value}) do
-    if number < check_value, do: true, else: %{item_name => "must be less than #{check_value}"}
+    if number < check_value, do: true, else: %{item_name => "must be less than #{check_value}. got: #{inspect number}"}
   end
 
   defp check_number(number, item_name, {:lt, check_value}) do
@@ -204,7 +205,7 @@ defmodule Exop.ValidationChecks do
   defp check_number(number, item_name, {:less_than_or_equal_to, check_value}) do
     if number <= check_value,
       do: true,
-      else: %{item_name => "must be less than or equal to #{check_value}"}
+      else: %{item_name => "must be less than or equal to #{check_value}. got: #{inspect number}"}
   end
 
   defp check_number(number, item_name, {:lte, check_value}) do
@@ -216,7 +217,7 @@ defmodule Exop.ValidationChecks do
   end
 
   defp check_number(_number, item_name, {check, _check_value}) do
-    %{item_name => "unknwon check '#{check}'"}
+    %{item_name => "unknown check '#{check}'"}
   end
 
   @doc """
@@ -234,7 +235,7 @@ defmodule Exop.ValidationChecks do
     if Enum.member?(check_list, check_item) do
       true
     else
-      %{item_name => "must be one of #{inspect(check_list)}"}
+      %{item_name => "must be one of #{inspect(check_list)}. got: #{inspect check_item}"}
     end
   end
 
@@ -253,7 +254,7 @@ defmodule Exop.ValidationChecks do
     check_item = get_check_item(check_items, item_name)
 
     if Enum.member?(check_list, check_item) do
-      %{item_name => "must not be included in #{inspect(check_list)}"}
+      %{item_name => "must not be included in #{inspect(check_list)}. got: #{inspect check_item}"}
     else
       true
     end
@@ -277,7 +278,7 @@ defmodule Exop.ValidationChecks do
       if Regex.match?(check, check_item) do
         true
       else
-        %{item_name => "has invalid format"}
+        %{item_name => "has invalid format. got: #{inspect check_item}"}
       end
     else
       true
@@ -343,12 +344,12 @@ defmodule Exop.ValidationChecks do
 
   defp check_length(:gte, item_name, actual_length, check_value) do
     actual_length >= check_value ||
-      %{item_name => "length must be greater than or equal to #{check_value}"}
+      %{item_name => "length must be greater than or equal to #{check_value}. got length: #{inspect actual_length}"}
   end
 
   defp check_length(:gt, item_name, actual_length, check_value) do
     actual_length > check_value ||
-      %{item_name => "length must be greater than #{check_value}"}
+      %{item_name => "length must be greater than #{check_value}. got length: #{inspect actual_length}"}
   end
 
   defp check_length(:max, item_name, actual_length, check_value) do
@@ -357,21 +358,21 @@ defmodule Exop.ValidationChecks do
 
   defp check_length(:lte, item_name, actual_length, check_value) do
     actual_length <= check_value ||
-      %{item_name => "length must be less than or equal to #{check_value}"}
+      %{item_name => "length must be less than or equal to #{check_value}. got length: #{inspect actual_length}"}
   end
 
   defp check_length(:lt, item_name, actual_length, check_value) do
     actual_length < check_value ||
-      %{item_name => "length must be less than #{check_value}"}
+      %{item_name => "length must be less than #{check_value}. got length: #{inspect actual_length}"}
   end
 
   defp check_length(:is, item_name, actual_length, check_value) do
-    actual_length == check_value || %{item_name => "length must be equal to #{check_value}"}
+    actual_length == check_value || %{item_name => "length must be equal to #{check_value}. got length: #{inspect actual_length}"}
   end
 
   defp check_length(:in, item_name, actual_length, check_value) do
     Enum.member?(check_value, actual_length) ||
-      %{item_name => "length must be in range #{check_value}"}
+      %{item_name => "length must be in range #{check_value}. got length: #{inspect actual_length}"}
   end
 
   defp check_length(check, item_name, _actual_length, _check_value) do
@@ -456,7 +457,7 @@ defmodule Exop.ValidationChecks do
     if check_item === check_value do
       true
     else
-      %{item_name => "must be equal to #{inspect(check_value)}"}
+      %{item_name => "must be equal to #{inspect(check_value)}. got: #{inspect check_item}"}
     end
   end
 
@@ -488,5 +489,6 @@ defmodule Exop.ValidationChecks do
 
   defp validate_struct(%struct{}, struct, _item_name) when is_atom(struct), do: true
 
-  defp validate_struct(_item, _check, item_name), do: %{item_name => "is not expected struct"}
+  defp validate_struct(item, check, item_name),
+       do: %{item_name => "is not expected struct. expected: #{inspect check}, got: #{inspect item}"}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Exop.Mixfile do
   def project do
     [
       app: :exop,
-      version: "1.3.4",
+      version: "1.3.5",
       elixir: ">= 1.6.0",
       name: "Exop",
       description: @description,

--- a/test/chain_test.exs
+++ b/test/chain_test.exs
@@ -99,7 +99,7 @@ defmodule ChainTest do
     initial_params = [a: 1, b: 2]
     result = TestChainFail.run(initial_params)
 
-    assert {:error, {:validation, %{a: ["has wrong type"]}}} = result
+    assert {:error, {:validation, %{a: ["has wrong type; expected type: string, got: 3"]}}} = result
   end
 
   test "invokes a fallback module of a failed operation" do
@@ -163,7 +163,10 @@ defmodule ChainTest do
     test "returns failed operation name" do
       initial_params = [a: 1, b: 2]
       result = TestChainFailOpname.run(initial_params)
-      assert {ChainTest.Fail, {:error, {:validation, %{a: ["has wrong type"]}}}} = result
+
+      assert {ChainTest.Fail,
+              {:error, {:validation, %{a: ["has wrong type; expected type: string, got: 3"]}}}} =
+               result
     end
 
     test "doesn't affect an operation with a fallback" do

--- a/test/fallback_test.exs
+++ b/test/fallback_test.exs
@@ -41,23 +41,28 @@ defmodule FallbackTest do
   describe "fallback wasnt defined" do
     test "operation returns its error" do
       result = TestOperation.run(a: "a", b: 2)
-      assert result == {:error, {:validation, %{a: ["has wrong type"]}}}
+
+      assert result ==
+               {:error, {:validation, %{a: ["has wrong type; expected type: integer, got: \"a\""]}}}
     end
   end
 
   describe "fallback was defined" do
     test "operation returns its error if there is no return: true in a fallback opts" do
       result = TestOperation1.run(a: "a", b: 2)
-      assert result == {:error, {:validation, %{a: ["has wrong type"]}}}
+
+      assert result ==
+               {:error, {:validation, %{a: ["has wrong type; expected type: integer, got: \"a\""]}}}
     end
 
     test "operation returns a fallback result if there is return: true in a fallback opts" do
       result = TestOperation2.run(a: "a", b: 2)
+
       assert result == {
-        FallbackTest.TestOperation2,
-        %{a: "a", b: 2},
-        {:error, {:validation, %{a: ["has wrong type"]}}}
-      }
+               FallbackTest.TestOperation2,
+               %{a: "a", b: 2},
+               {:error, {:validation, %{a: ["has wrong type; expected type: integer, got: \"a\""]}}}
+             }
     end
   end
 end

--- a/test/operation_test.exs
+++ b/test/operation_test.exs
@@ -341,7 +341,9 @@ defmodule OperationTest do
     end
 
     assert Def18Operation.run(a: 2) == {:ok, 4}
-    assert Def18Operation.run(a: 0) == {:error, {:validation, %{a: ["must be greater than 0"]}}}
+
+    assert Def18Operation.run(a: 0) ==
+             {:error, {:validation, %{a: ["must be greater than 0; got: 0"]}}}
 
     assert Def19Operation.run() == {:ok, "str"}
 
@@ -473,7 +475,8 @@ defmodule OperationTest do
 
     assert Def29Operation.run() ==
              {:error,
-              {:validation, %{"list_param[1]" => ["length must be greater than or equal to 7"]}}}
+              {:validation,
+               %{"list_param[1]" => ["length must be greater than or equal to 7; got length: 6"]}}}
   end
 
   test "list_item + coerce_with" do
@@ -491,7 +494,8 @@ defmodule OperationTest do
 
     assert Def30Operation.run() ==
              {:error,
-              {:validation, %{"list_param[1]" => ["length must be greater than or equal to 7"]}}}
+              {:validation,
+               %{"list_param[1]" => ["length must be greater than or equal to 7; got length: 6"]}}}
   end
 
   test "string-named parameters are allowed" do
@@ -508,7 +512,12 @@ defmodule OperationTest do
              {:error, {:validation, %{"a" => ["is required"], "b" => ["is required"]}}}
 
     assert Def31Operation.run(%{"a" => 1, "b" => "2"}) ==
-             {:error, {:validation, %{"a" => ["has wrong type"], "b" => ["has wrong type"]}}}
+             {:error,
+              {:validation,
+               %{
+                 "a" => ["has wrong type; expected type: string, got: 1"],
+                 "b" => ["has wrong type; expected type: integer, got: \"2\""]
+               }}}
 
     assert Def31Operation.run(%{"a" => "1", b: 2}) ==
              {:error, {:validation, %{"b" => ["is required"]}}}
@@ -530,7 +539,12 @@ defmodule OperationTest do
              {:error, {:validation, %{"a" => ["is required"], :b => ["is required"]}}}
 
     assert Def32Operation.run(%{"a" => 1, b: "2"}) ==
-             {:error, {:validation, %{"a" => ["has wrong type"], :b => ["has wrong type"]}}}
+             {:error,
+              {:validation,
+               %{
+                 :b => ["has wrong type; expected type: integer, got: \"2\""],
+                 "a" => ["has wrong type; expected type: string, got: 1"]
+               }}}
 
     assert Def32Operation.run(%{"a" => "1"}) == {:error, {:validation, %{:b => ["is required"]}}}
     assert Def32Operation.run(%{"a" => "1", b: 2}) == {:ok, %{"a" => "1", :b => 2}}
@@ -611,10 +625,19 @@ defmodule OperationTest do
       end
 
       assert Def37Operation.run(a: nil) == {:ok, %{a: nil}}
-      assert Def37Operation.run(a: 1) == {:error, {:validation, %{a: ["must be greater than 2"]}}}
+
+      assert Def37Operation.run(a: 1) ==
+               {:error, {:validation, %{a: ["must be greater than 2; got: 1"]}}}
 
       assert Def37Operation.run(a: "1") ==
-               {:error, {:validation, %{a: ["not a number", "has wrong type"]}}}
+               {:error,
+                {:validation,
+                 %{
+                   a: [
+                     "not a number. got: \"1\"",
+                     "has wrong type; expected type: integer, got: \"1\""
+                   ]
+                 }}}
 
       assert Def37Operation.run(b: nil) == {:ok, %{b: nil}}
 
@@ -795,7 +818,9 @@ defmodule OperationTest do
       end
 
       assert Def47Operation.run(a: :a) == {:ok, %{a: :a}}
-      assert Def47Operation.run(a: "a") == {:error, {:validation, %{a: ["has wrong type"]}}}
+
+      assert Def47Operation.run(a: "a") ==
+               {:error, {:validation, %{a: ["has wrong type; expected type: atom, got: \"a\""]}}}
     end
   end
 
@@ -816,7 +841,7 @@ defmodule OperationTest do
     assert Def48Operation.run(%Def48Struct{a: 1, b: "1"}) == {:ok, %{a: 1, b: "1"}}
 
     assert Def48Operation.run(%Def48Struct{a: "1", b: "1"}) ==
-             {:error, {:validation, %{a: ["has wrong type"]}}}
+             {:error, {:validation, %{a: ["has wrong type; expected type: integer, got: \"1\""]}}}
   end
 
   describe ":from option" do
@@ -845,11 +870,13 @@ defmodule OperationTest do
       assert Def49Operation.run(%{"a" => 1, bB: "1"}) == {:ok, %{a: 1, b: "1"}}
 
       assert Def49Operation.run(%{"a" => 1, bB: 1}) ==
-               {:error, {:validation, %{b: ["has wrong type"]}}}
+               {:error, {:validation, %{b: ["has wrong type; expected type: string, got: 1"]}}}
 
       assert Def50Operation.run(a: 1, b: "1") == {:ok, %{a: 1, b: "1"}}
       assert Def50Operation.run(aA: 1, bB: "1") == {:ok, %{a: 1, b: "1"}}
-      assert Def50Operation.run(aA: 1, bB: 1) == {:error, {:validation, %{b: ["has wrong type"]}}}
+
+      assert Def50Operation.run(aA: 1, bB: 1) ==
+               {:error, {:validation, %{b: ["has wrong type; expected type: string, got: 1"]}}}
     end
   end
 

--- a/test/validation_checks_test.exs
+++ b/test/validation_checks_test.exs
@@ -462,4 +462,30 @@ defmodule ValidationChecksTest do
              %{a: "must be less than or equal to 1; got: 3"}
            ]
   end
+
+  test "subset_of/3: success" do
+    assert check_subset_of(%{a: ["b"]}, :a, [1, 2, :a, "b", C]) == true
+    assert check_subset_of(%{a: [2, "b", C]}, :a, [1, 2, :a, "b", C]) == true
+    assert check_subset_of(%{a: [1, 2, :a, "b", C]}, :a, [1, 2, :a, "b", C]) == true
+  end
+
+  test "subset_of/3: fails" do
+    assert check_subset_of(%{a: :b}, :a, [1, 2, :a, "b", C]) == %{a: "must be a list; got: :b"}
+
+    assert check_subset_of(%{a: []}, :a, [1, 2, :a, "b", C]) == %{
+             a: "must be a subset of [1, 2, :a, \"b\", C]; got: []"
+           }
+
+    assert check_subset_of(%{a: [3]}, :a, [1, 2, :a, "b", C]) == %{
+             a: "must be a subset of [1, 2, :a, \"b\", C]; got: [3]"
+           }
+
+    assert check_subset_of(%{a: [1, 2, 3]}, :a, [1, 2, :a, "b", C]) == %{
+             a: "must be a subset of [1, 2, :a, \"b\", C]; got: [1, 2, 3]"
+           }
+
+    assert check_subset_of(%{a: [1, 2, :a, 3, "b", C]}, :a, [1, 2, :a, "b", C]) == %{
+             a: "must be a subset of [1, 2, :a, \"b\", C]; got: [1, 2, :a, 3, \"b\", C]"
+           }
+  end
 end

--- a/test/validation_checks_test.exs
+++ b/test/validation_checks_test.exs
@@ -53,7 +53,9 @@ defmodule ValidationChecksTest do
   end
 
   test "check_type/3: returns false if item is of unknown type" do
-    assert %{a: "has wrong type"} == check_type(%{a: 1}, :a, :unknown)
+    assert check_type(%{a: 1}, :a, :unknown) == %{
+             a: "has wrong type; expected type: unknown, got: 1"
+           }
   end
 
   test "check_type/3: returns true if item is one of handled type" do
@@ -66,7 +68,9 @@ defmodule ValidationChecksTest do
   end
 
   test "check_type/3: returns false if item is nil but type is not atom" do
-    assert check_type(%{a: nil}, :a, :string) == %{:a => "has wrong type"}
+    assert check_type(%{a: nil}, :a, :string) == %{
+             :a => "has wrong type; expected type: string, got: nil"
+           }
   end
 
   test "check_type/3: checks module" do
@@ -74,26 +78,53 @@ defmodule ValidationChecksTest do
     end
 
     assert check_type(%{a: TestModule}, :a, :module) == true
-    assert check_type(%{a: TestModule_2}, :a, :module) == %{a: "has wrong type"}
-    assert check_type(%{a: :atom}, :a, :module) == %{a: "has wrong type"}
-    assert check_type(%{a: 1}, :a, :module) == %{a: "has wrong type"}
+
+    assert check_type(%{a: TestModule_2}, :a, :module) == %{
+             a: "has wrong type; expected type: module, got: TestModule_2"
+           }
+
+    assert check_type(%{a: :atom}, :a, :module) == %{
+             a: "has wrong type; expected type: module, got: :atom"
+           }
+
+    assert check_type(%{a: 1}, :a, :module) == %{
+             a: "has wrong type; expected type: module, got: 1"
+           }
   end
 
   test "check_type/3: checks keyword" do
     assert check_type(%{a: [b: 1, c: "2"]}, :a, :keyword) == true
     assert check_type(%{a: [{:b, 1}, {:c, "2"}]}, :a, :keyword) == true
     assert check_type(%{a: []}, :a, :keyword) == true
-    assert check_type(%{a: :atom}, :a, :keyword) == %{a: "has wrong type"}
-    assert check_type(%{a: %{b: 1, c: "2"}}, :a, :keyword) == %{a: "has wrong type"}
+
+    assert check_type(%{a: :atom}, :a, :keyword) == %{
+             a: "has wrong type; expected type: keyword, got: :atom"
+           }
+
+    assert check_type(%{a: %{b: 1, c: "2"}}, :a, :keyword) == %{
+             a: "has wrong type; expected type: keyword, got: %{b: 1, c: \"2\"}"
+           }
   end
 
   test "check_type/3: checks structs" do
     assert check_type(%{a: %TestStruct{qwerty: :asdfgh}}, :a, :struct) == true
     assert check_type(%{a: %TestStruct{}}, :a, :struct) == true
-    assert check_type(%{a: %{b: 1, c: "2"}}, :a, :struct) == %{a: "has wrong type"}
-    assert check_type(%{a: %{}}, :a, :struct) == %{a: "has wrong type"}
-    assert check_type(%{a: [{:b, 1}, {:c, "2"}]}, :a, :struct) == %{a: "has wrong type"}
-    assert check_type(%{a: :atom}, :a, :struct) == %{a: "has wrong type"}
+
+    assert check_type(%{a: %{b: 1, c: "2"}}, :a, :struct) == %{
+             a: "has wrong type; expected type: struct, got: %{b: 1, c: \"2\"}"
+           }
+
+    assert check_type(%{a: %{}}, :a, :struct) == %{
+             a: "has wrong type; expected type: struct, got: %{}"
+           }
+
+    assert check_type(%{a: [{:b, 1}, {:c, "2"}]}, :a, :struct) == %{
+             a: "has wrong type; expected type: struct, got: [b: 1, c: \"2\"]"
+           }
+
+    assert check_type(%{a: :atom}, :a, :struct) == %{
+             a: "has wrong type; expected type: struct, got: :atom"
+           }
   end
 
   test "check_type/3: checks uuids" do
@@ -102,11 +133,23 @@ defmodule ValidationChecksTest do
     # uuid 4
     assert check_type(%{a: "7b79b77b-bc4c-4de1-a81f-1a07fc3289c2"}, :a, :uuid) == true
 
-    assert check_type(%{a: ""}, :a, :uuid) == %{a: "has wrong type"}
-    assert check_type(%{a: "qwerty"}, :a, :uuid) == %{a: "has wrong type"}
-    assert check_type(%{a: "qwerty-asdf"}, :a, :uuid) == %{a: "has wrong type"}
-    assert check_type(%{a: :b}, :a, :uuid) == %{a: "has wrong type"}
-    assert check_type(%{a: 1}, :a, :uuid) == %{a: "has wrong type"}
+    assert check_type(%{a: ""}, :a, :uuid) == %{a: "has wrong type; expected type: uuid, got: \"\""}
+
+    assert check_type(%{a: "qwerty"}, :a, :uuid) == %{
+             a: "has wrong type; expected type: uuid, got: \"qwerty\""
+           }
+
+    assert check_type(%{a: "qwerty-asdf"}, :a, :uuid) == %{
+             a: "has wrong type; expected type: uuid, got: \"qwerty-asdf\""
+           }
+
+    assert check_type(%{a: :b}, :a, :uuid) == %{
+             a: "has wrong type; expected type: uuid, got: :b"
+           }
+
+    assert check_type(%{a: 1}, :a, :uuid) == %{
+             a: "has wrong type; expected type: uuid, got: 1"
+           }
   end
 
   test "check_numericality/3: returns %{item_name => error_msg} if item is in params and is not a number" do
@@ -274,24 +317,34 @@ defmodule ValidationChecksTest do
   end
 
   test "check_struct/3: fails" do
-    assert check_struct(%{a: %TestStruct2{}}, :a, %TestStruct{}) == %{a: "is not expected struct"}
+    assert check_struct(%{a: %TestStruct2{}}, :a, %TestStruct{}) == %{
+             a:
+               "is not expected struct; expected: ValidationChecksTest.TestStruct; got: ValidationChecksTest.TestStruct2"
+           }
 
     assert check_struct(%{a: %TestStruct2{qwerty: "123"}}, :a, %TestStruct{}) == %{
-             a: "is not expected struct"
+             a:
+               "is not expected struct; expected: ValidationChecksTest.TestStruct; got: ValidationChecksTest.TestStruct2"
            }
 
     assert check_struct(%{a: %TestStruct2{}}, :a, %TestStruct{qwerty: "123"}) == %{
-             a: "is not expected struct"
+             a:
+               "is not expected struct; expected: ValidationChecksTest.TestStruct; got: ValidationChecksTest.TestStruct2"
            }
 
     assert check_struct(%{a: %TestStruct2{qwerty: "123"}}, :a, %TestStruct{qwerty: "123"}) == %{
-             a: "is not expected struct"
+             a:
+               "is not expected struct; expected: ValidationChecksTest.TestStruct; got: ValidationChecksTest.TestStruct2"
            }
 
-    assert check_struct(%{a: %TestStruct2{}}, :a, TestStruct) == %{a: "is not expected struct"}
+    assert check_struct(%{a: %TestStruct2{}}, :a, TestStruct) == %{
+             a:
+               "is not expected struct; expected: ValidationChecksTest.TestStruct; got: ValidationChecksTest.TestStruct2"
+           }
 
     assert check_struct(%{a: %TestStruct2{qwerty: "123"}}, :a, TestStruct) == %{
-             a: "is not expected struct"
+             a:
+               "is not expected struct; expected: ValidationChecksTest.TestStruct; got: ValidationChecksTest.TestStruct2"
            }
   end
 
@@ -304,14 +357,20 @@ defmodule ValidationChecksTest do
   end
 
   test "check_equals/3: fails" do
-    assert check_equals(%{a: 1.0}, :a, 1) == %{a: "must be equal to 1"}
-    assert check_equals(%{a: 1.0}, :a, 1.1) == %{a: "must be equal to 1.1"}
-    assert check_equals(%{a: :a}, :a, :b) == %{a: "must be equal to :b"}
-    assert check_equals(%{a: [b: 2, c: 3]}, :a, b: 2, c: 1) == %{a: "must be equal to [b: 2, c: 1]"}
-    assert check_equals(%{a: [b: 2, c: 3]}, :a, [{:b, 2}]) == %{a: "must be equal to [b: 2]"}
+    assert check_equals(%{a: 1.0}, :a, 1) == %{a: "must be equal to 1; got: 1.0"}
+    assert check_equals(%{a: 1.0}, :a, 1.1) == %{a: "must be equal to 1.1; got: 1.0"}
+    assert check_equals(%{a: :a}, :a, :b) == %{a: "must be equal to :b; got: :a"}
+
+    assert check_equals(%{a: [b: 2, c: 3]}, :a, b: 2, c: 1) == %{
+             a: "must be equal to [b: 2, c: 1]; got: [b: 2, c: 3]"
+           }
+
+    assert check_equals(%{a: [b: 2, c: 3]}, :a, [{:b, 2}]) == %{
+             a: "must be equal to [b: 2]; got: [b: 2, c: 3]"
+           }
 
     assert check_equals(%{a: %{b: 2, c: 3}}, :a, %{b: 2, d: 3}) == %{
-             a: "must be equal to %{b: 2, d: 3}"
+             a: "must be equal to %{b: 2, d: 3}; got: %{b: 2, c: 3}"
            }
   end
 
@@ -324,18 +383,20 @@ defmodule ValidationChecksTest do
   end
 
   test "check_exactly/3: fails" do
-    assert check_exactly(%{a: 1.0}, :a, 1) == %{a: "must be equal to 1"}
-    assert check_exactly(%{a: 1.0}, :a, 1.1) == %{a: "must be equal to 1.1"}
-    assert check_exactly(%{a: :a}, :a, :b) == %{a: "must be equal to :b"}
+    assert check_exactly(%{a: 1.0}, :a, 1) == %{a: "must be equal to 1; got: 1.0"}
+    assert check_exactly(%{a: 1.0}, :a, 1.1) == %{a: "must be equal to 1.1; got: 1.0"}
+    assert check_exactly(%{a: :a}, :a, :b) == %{a: "must be equal to :b; got: :a"}
 
     assert check_exactly(%{a: [b: 2, c: 3]}, :a, b: 2, c: 1) == %{
-             a: "must be equal to [b: 2, c: 1]"
+             a: "must be equal to [b: 2, c: 1]; got: [b: 2, c: 3]"
            }
 
-    assert check_exactly(%{a: [b: 2, c: 3]}, :a, [{:b, 2}]) == %{a: "must be equal to [b: 2]"}
+    assert check_exactly(%{a: [b: 2, c: 3]}, :a, [{:b, 2}]) == %{
+             a: "must be equal to [b: 2]; got: [b: 2, c: 3]"
+           }
 
     assert check_exactly(%{a: %{b: 2, c: 3}}, :a, %{b: 2, d: 3}) == %{
-             a: "must be equal to %{b: 2, d: 3}"
+             a: "must be equal to %{b: 2, d: 3}; got: %{b: 2, c: 3}"
            }
   end
 
@@ -386,16 +447,19 @@ defmodule ValidationChecksTest do
 
   test "check_numericality/3: aliases" do
     assert check_numericality(%{a: 3}, :a, %{equals: 3}) == true
-    assert check_numericality(%{a: 2}, :a, %{equals: 3}) == [%{a: "must be equal to 3"}]
+    assert check_numericality(%{a: 2}, :a, %{equals: 3}) == [%{a: "must be equal to 3; got: 2"}]
     assert check_numericality(%{a: 3}, :a, %{is: 3}) == true
-    assert check_numericality(%{a: 2}, :a, %{is: 3}) == [%{a: "must be equal to 3"}]
+    assert check_numericality(%{a: 2}, :a, %{is: 3}) == [%{a: "must be equal to 3; got: 2"}]
     assert check_numericality(%{a: 3}, :a, %{min: 1}) == true
 
     assert check_numericality(%{a: 1}, :a, %{min: 3}) == [
-             %{a: "must be greater than or equal to 3"}
+             %{a: "must be greater than or equal to 3; got: 1"}
            ]
 
     assert check_numericality(%{a: 1}, :a, %{max: 3}) == true
-    assert check_numericality(%{a: 3}, :a, %{max: 1}) == [%{a: "must be less than or equal to 1"}]
+
+    assert check_numericality(%{a: 3}, :a, %{max: 1}) == [
+             %{a: "must be less than or equal to 1; got: 3"}
+           ]
   end
 end

--- a/test/validation_test.exs
+++ b/test/validation_test.exs
@@ -41,8 +41,8 @@ defmodule ValidationTest do
                %{param: "is required"},
                true,
                true,
-               %{param2: "has wrong type"},
-               %{param2: "must be one of [1, 2, 3]"}
+               %{param2: "has wrong type; expected type: integer, got: \"some_value\""},
+               %{param2: "must be one of [1, 2, 3]; got: \"some_value\""}
              ]
   end
 
@@ -159,10 +159,10 @@ defmodule ValidationTest do
 
     assert %{
              "list_param[0]" => [
-               "has wrong type",
+               "has wrong type; expected type: string, got: 1",
                "length check supports only lists, binaries, atoms, maps and tuples"
              ],
-             "list_param[1]" => ["length must be greater than or equal to 7"],
+             "list_param[1]" => ["length must be greater than or equal to 7; got length: 6"],
              "list_param[2]" => ["doesn't allow nil"]
            } == reasons
   end
@@ -193,8 +193,8 @@ defmodule ValidationTest do
     {:error, {:validation, reasons}} = valid?(contract, received_params)
 
     assert %{
-             "list_param[0][:b]" => ["length must be greater than or equal to 7"],
-             "list_param[1][:a]" => ["has wrong type"]
+             "list_param[0][:b]" => ["length must be greater than or equal to 7; got length: 6"],
+             "list_param[1][:a]" => ["has wrong type; expected type: integer, got: \"3\""]
            } == reasons
   end
 


### PR DESCRIPTION
- basic validation message extension with "got:" (credits to https://github.com/sgilson)
makes error-tuple messages more descriptive
- new `:subset_of` check allows you to check whether a given list is a subset of defined check-list