### PR TITLE
v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.4.2] - yyyy.mm.dd
+
+- a bug in `coerce_with/2` was fixed: a parameter got coerced (as `nil`) even if it is not required
+
 ## [1.4.1] - 2020.06.08
 
 - `Code.ensure_compiled/1` instead of deprecated `Code.ensure_compiled?/1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [1.4.2] - yyyy.mm.dd
 
 - a bug in `coerce_with/2` was fixed: a parameter got coerced (as `nil`) even if it is not required
+- `run!` raises an `Exop.Operation.ErrorResult` error when an operation returns an error tuple
 
 ## [1.4.1] - 2020.06.08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.4.2] - yyyy.mm.dd
+## [1.4.2] - 2019.09.21
 
 - a bug in `coerce_with/2` was fixed: a parameter got coerced (as `nil`) even if it is not required
 - `run!` raises an `Exop.Operation.ErrorResult` error when an operation returns an error tuple

--- a/README.md
+++ b/README.md
@@ -619,7 +619,8 @@ There is "bang" version of `run/1` exists. Function `run!/1` does the same thing
 the only difference is a result of invocation, it might be:
 
 - if a contract validation passed - the actual result of an operation (result of a code, described in `process/1`)
-- if a contract validation failed - an error `Exop.Validation.ValidationError` raising
+- if a contract validation failed - an error `Exop.Validation.ValidationError` is raised
+- if an operation returns an error tuple - an error `Exop.Operation.ErrorResult` is raised
 - in case of manual interruption - `{:interrupt, _reason}`
 
 _You always can bypass the validation simply by calling `process/1` function itself, if needed._

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Exop.Mixfile do
   def project do
     [
       app: :exop,
-      version: "1.4.1",
+      version: "1.4.2",
       elixir: ">= 1.6.0",
       name: "Exop",
       description: @description,

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Exop.Mixfile do
   defp package do
     [
       files: ["lib", "mix.exs", "README.md", "LICENSE"],
-      maintainers: ["Andrey Chernykh", "Aleksandr Fomin"],
+      maintainers: ["Andrey Chernykh"],
       licenses: ["MIT"],
       links: %{"Github" => "https://github.com/madeinussr/exop"}
     ]

--- a/test/operation_test.exs
+++ b/test/operation_test.exs
@@ -418,17 +418,17 @@ defmodule OperationTest do
     assert Def25Operation.run(param: 111) == {:error, :ooops}
   end
 
-  test "run!/1: returns unwrapped error tuple if process/1 returns it" do
-    defmodule Def26Operation do
-      use Exop.Operation
+  # test "run!/1: returns unwrapped error tuple if process/1 returns it" do
+  #   defmodule Def26Operation do
+  #     use Exop.Operation
 
-      parameter :param
+  #     parameter :param
 
-      def process(_params), do: {:error, :ooops}
-    end
+  #     def process(_params), do: {:error, :ooops}
+  #   end
 
-    assert Def26Operation.run!(param: 111) == {:error, :ooops}
-  end
+  #   assert Def26Operation.run!(param: 111) == {:error, :ooops}
+  # end
 
   test "custom validation function takes a {param_name, param_value} tuple as the first argument" do
     defmodule Def27Operation do
@@ -1003,5 +1003,19 @@ defmodule OperationTest do
     assert Def56Operation.run(a: 1) == {:ok, %{a: "1"}}
     assert Def56Operation.run(a: nil) == {:ok, %{a: ""}}
     assert Def56Operation.run() == {:ok, %{}}
+  end
+
+  test "run!/1: returns Exop.Operation.ErrorResult error if error tuple has been returned" do
+    defmodule Def57Operation do
+      use Exop.Operation
+
+      parameter :param, required: true
+
+      def process(_params), do: {:error, :some_error_message}
+    end
+
+    assert_raise Exop.Operation.ErrorResult,
+                 "Elixir.OperationTest.Def57Operation returned: \n{:error, :some_error_message}",
+                 fn -> Def57Operation.run!(param: "hi!") end
   end
 end


### PR DESCRIPTION
- a bug in `coerce_with/2` was fixed: a parameter got coerced (as `nil`) even if it is not required
- `run!` raises an `Exop.Operation.ErrorResult` error when an operation returns an error tuple