### PR TITLE
Fix do_authorize's typespec

### DIFF
--- a/lib/exop/operation.ex
+++ b/lib/exop/operation.ex
@@ -190,7 +190,7 @@ defmodule Exop.Operation do
         throw({@exop_interruption, reason})
       end
 
-      @spec do_authorize(module(), atom(), any()) :: no_return()
+      @spec do_authorize(module(), atom(), any()) :: :ok | no_return()
       defp do_authorize(nil, _action, _opts) do
         throw({@exop_auth_error, :undefined_policy})
       end


### PR DESCRIPTION
Hi there! It looks like `do_authorize` was typespecced to never return anything. Of course it can also return `:ok`, so this PR just adds that to the typespec.

As it currently stands, any code using `authorize` would get Dialyzer warnings that say:

```
Function process/1 has no local return.
```

And then anything calling `run/1` would get Dialyzer warnings like below, since Dialyzer thinks `process` always raises if `authorize` is called:

```
The pattern can never match the type.

Pattern:
{:ok, _result}

Type:
{:error, _} | {:interrupt, _}
```